### PR TITLE
Hotfix: CD no longer builds for 3.14

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,6 +80,7 @@ jobs:
     - name: Build wheels
       run: uv tool run cibuildwheel --output-dir wheelhouse
       env:
+        CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
         CIBW_SKIP: pp* cp36-* cp37-* cp38-* *-win32 *i686* *-musllinux*
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: "uv tool install maturin"


### PR DESCRIPTION
It's failing and I don't have time to debug. Let's deploy without 3.14 for now, raised as #16 