### PR TITLE
Reconciled pytest marks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,10 @@ This project uses `just` as a command runner with a modular structure and `uv` f
   - `just build`: Standard development build
   - `just build pgo`: Profile-Guided Optimisation build for maximum performance
 - `just test`: Run test suite (see `just test list` for options)
-  - `just test`: Run all tests (Python integration + Rust core)
-  - `just test python`: Run Python integration tests only
-  - `just test rust`: Run Rust core tests only
+  - `just test`: Fast tests only (Python + Rust, <30s)
+  - `just test all`: All tests including slow tests (complete validation, 2-5min)
+  - `just test python`: Python tests only (fast)
+  - `just test rust`: Rust core tests only
 - `just bench`: Run benchmarks (see `just bench list` for options)
   - `just bench rust`: Rust core benchmarks for performance validation
   - `just bench collection`: End-to-end processing benchmarks (accepts scale parameter)
@@ -81,7 +82,7 @@ This project uses `just` as a command runner with a modular structure and `uv` f
 
 ## Testing strategy
 
-The project uses a **three-layer testing approach** that achieves comprehensive coverage whilst maintaining system safety:
+The project uses a **three-layer testing approach** that achieves comprehensive coverage whilst maintaining development velocity:
 
 **Layer 1: Pure Rust core tests** (69 tests)
 - All business logic tested in `starlings-core` crate
@@ -89,23 +90,25 @@ The project uses a **three-layer testing approach** that achieves comprehensive 
 - Full coverage of data structures, algorithms, and edge cases
 - Run via: `cargo test -p starlings-core`
 
-**Layer 2: Python integration tests** (19 tests)
-- Unit tests with small datasets (< 1000 entities) for basic functionality
-- E2E tests with production-scale datasets (100k-1M entities) for safety validation
-- Tests PyO3 wrapper functionality, type conversions, error handling
+**Layer 2: Python integration tests** (~70 tests)
+- **Fast tests** (default): Small to medium datasets, complete in <30s
+- **Slow tests** (optional): Large-scale datasets (100k-1M entities), complete in 2-5min
+- Tests PyO3 wrapper functionality, type conversions, error handling, safety validation
 - **SAFE**: All tests run with `STARLINGS_MEMORY_LIMIT=50%`
-- Run via: `just test` (safe by default with production validation)
+- Run via: `just test` (fast tests only) or `just test all` (complete validation)
 - **IMPORTANT**: When running Python tests directly (not via `just`), always use `uv run pytest` to ensure correct virtual environment
 
-**Layer 3: Stress testing** (12+ tests)  
-- Memory pressure simulation, resource exhaustion scenarios
-- Circuit breaker validation under artificial system stress
-- **DANGEROUS**: Artificially consumes system resources to test limits
-- Run via: `just test dangerous` (explicit opt-in required)
+**Layer 3: Benchmarks** (9 tests in separate suite)
+- Performance benchmarks for Rust core and end-to-end processing
+- Production-scale performance testing with PGO builds
+- Run via: `just bench` (never included in test suite)
 
 This **"Rust Core with Python Bindings"** pattern ensures complete test coverage whilst avoiding complex PyO3 test configuration. The Rust core handles all business logic testing, whilst Python tests validate the integration boundary.
 
-**Safety by Default**: The default `just test` command runs safe tests including production-scale validation that demonstrate the safety system working correctly. The safety system automatically prevents system crashes during large-scale operations. Only stress tests that artificially exhaust system resources require explicit opt-in via `just test dangerous`.
+**Testing workflow**:
+- **Development** (continuous): `just test` - fast tests only (~70 tests, <30s)
+- **Pre-commit** (occasional): `just test all` - all tests including slow (~75 tests, 2-5min)
+- **Performance validation**: `just bench` - benchmarks only (separate suite)
 
 ### Benchmarking and performance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,13 +68,8 @@ testpaths = [
     "src/tests",
 ]
 markers = [
-    "benchmark: marks tests as benchmarks (deselect with '-m \"not benchmark\"')",
-    "safety: marks tests as safety mechanism tests",
-    "stress: marks tests as stress/load tests", 
-    "performance: marks tests as performance impact tests",
-    "integration: marks tests as integration tests",
-    "e2e: marks tests as end-to-end validation tests",
-    "slow: marks tests as slow-running tests",
+    "benchmark: marks tests as benchmarks (run via just bench)",
+    "slow: marks tests as slow-running tests (>5s, large datasets)",
 ]
 addopts = "-m 'not benchmark'"
 log_cli = true

--- a/src/tests/e2e/test_e2e_out_of_core.py
+++ b/src/tests/e2e/test_e2e_out_of_core.py
@@ -13,7 +13,7 @@ from starlings import generators
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.e2e
+@pytest.mark.slow
 class TestEndToEndOutOfCore:
     """End-to-end validation of complete out-of-core processing system."""
 

--- a/src/tests/e2e/test_e2e_workflow.py
+++ b/src/tests/e2e/test_e2e_workflow.py
@@ -10,7 +10,7 @@ from starlings import generators
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.e2e
+@pytest.mark.slow
 def test_user_eda_workflow():
     """Production-scale EDA workflow: Million-record minimum scale for library."""
     # Million-scale is the MINIMUM expected dataset size for production use

--- a/src/tests/justfile
+++ b/src/tests/justfile
@@ -5,35 +5,29 @@ set export
 STARLINGS_DEBUG := "1"
 STARLINGS_MEMORY_LIMIT := "50%"
 
-# Run all tests (Python + Rust) - SAFE BY DEFAULT with safety validation
+# Run fast tests (Python + Rust) - default for continuous development
 default: python rust
-    @echo "✅ Ran safe tests with production-scale safety validation (Python + Rust). Use 'just test dangerous' for stress tests."
+    @echo "✅ Fast tests passed (Python + Rust). Use 'just test all' for complete validation."
 
 # List all commands
 list:
     just -f ./src/tests/justfile --list
 
-# Run Python tests (safe tests + e2e safety validation)
+# Run Python tests (fast tests only, excludes slow tests)
 python:
-    @echo "Running Python tests (unit tests + e2e safety validation)..."
-    uv run pytest -m "not stress and not safety and not benchmark and not integration and not performance"
+    @echo "Running Python tests (fast tests, <30s)..."
+    uv run pytest -m "not benchmark and not slow"
+
+# Run all Python tests including slow tests
+all-python:
+    @echo "Running all Python tests including slow tests..."
+    uv run pytest -m "not benchmark"
 
 # Run only Rust tests
 rust:
     @echo "Running Rust core tests..."
     cargo test -p starlings-core
 
-# Run safety tests (memory limits, production scenarios)
-safety:
-    @echo "Running safety mechanism tests..."
-    STARLINGS_MEMORY_LIMIT=1GB uv run pytest src/tests/test_safety.py -v -m safety
-
-# Run end-to-end tests (large datasets, use with caution)
-e2e:
-    @echo "Running end-to-end tests (large datasets)..."
-    @echo "⚠️  WARNING: These tests use large datasets and may consume significant resources"
-    uv run pytest src/tests/e2e/ -v -m e2e
-
-# Run all dangerous tests (e2e large datasets)
-dangerous: safety e2e
-    @echo "✅ All dangerous tests completed"
+# Run all tests including slow tests (complete validation)
+all: all-python rust
+    @echo "✅ All tests passed (Python + Rust, including slow tests)"

--- a/src/tests/test_expressions.py
+++ b/src/tests/test_expressions.py
@@ -588,7 +588,7 @@ class TestNewMetricsIntegration:
             assert "method_b_threshold" in result
 
 
-@pytest.mark.integration
+@pytest.mark.slow
 class TestLargeScaleExpressions:
     """Test expression API with large-scale datasets."""
 

--- a/src/tests/test_safety.py
+++ b/src/tests/test_safety.py
@@ -6,12 +6,10 @@ production-scale scenarios, without requiring artificial memory pressure.
 
 import os
 
-import pytest
 import starlings as sl
 from starlings import generators
 
 
-@pytest.mark.safety
 class TestSafetyMechanisms:
     """Test that operations respect memory limits."""
 


### PR DESCRIPTION
The marks has got silly. Reconciled them to `just test`, `just test all`, and `just bench ...`.