### PR TITLE
Changed MergeEvent to only capture the delta roaring bitmap

### DIFF
--- a/src/rust/starlings-core/src/frame/translation.rs
+++ b/src/rust/starlings-core/src/frame/translation.rs
@@ -105,17 +105,20 @@ fn translate_merge_events(
     let source_merges = hierarchy.get_merge_events();
 
     for merge in source_merges {
-        let mut translated_groups = Vec::new();
+        // Translate parent_id
+        let new_parent_id = translation_map
+            .translate(merge.parent_id)
+            .ok_or_else(|| format!("Failed to translate parent_id {}", merge.parent_id))?;
 
-        for group in merge.merging_groups() {
-            let translated_group = translation_map.translate_bitmap(group);
-            if !translated_group.is_empty() {
-                translated_groups.push(translated_group);
-            }
-        }
+        // Translate child_nodes bitmap
+        let new_child_nodes = translation_map.translate_bitmap(&merge.child_nodes);
 
-        if !translated_groups.is_empty() {
-            translated_merges.push(MergeEvent::new(merge.threshold(), translated_groups));
+        if !new_child_nodes.is_empty() {
+            translated_merges.push(MergeEvent::new(
+                merge.threshold,
+                new_parent_id,
+                new_child_nodes,
+            ));
         }
     }
 

--- a/src/rust/starlings-core/src/hierarchy/builder.rs
+++ b/src/rust/starlings-core/src/hierarchy/builder.rs
@@ -73,11 +73,11 @@ impl ComponentManager<'_> {
         }
     }
 
-    fn create_merged_component(&self, components: &[RoaringBitmap]) -> RoaringBitmap {
+    fn create_merged_component(&self, components: &[&RoaringBitmap]) -> RoaringBitmap {
         let total_size = components.iter().map(|b| b.len()).sum::<u64>() as u32;
         let (mut merged, _) = self.bitmap_pool.get(total_size);
         for component in components {
-            merged |= component;
+            merged |= *component;
         }
         merged
     }
@@ -108,7 +108,7 @@ impl ChainDetector {
     fn record_merge(
         &mut self,
         merged_component: &RoaringBitmap,
-        merging_components: &[RoaringBitmap],
+        merging_components: &[&RoaringBitmap],
     ) {
         self.edges_processed += 1;
 
@@ -172,9 +172,9 @@ impl ChainDetector {
                  - Entity resolution model needs better tuning (thresholds too low?)\n\
                  - Data needs more cleaning before matching\n\
                  \n\
-                 If you're using synthetic test data, create realistic clusters instead:\n\
+                 If you are using synthetic test data, create realistic clusters instead:\n\
                  \n\
-                   # ❌ Don't create chains:\n\
+                   # ❌ Do not create chains:\n\
                    edges = [(i, i+1, 0.85) for i in range(n)]\n\
                  \n\
                    # ✅ Do create clusters (100 records per group):\n\
@@ -264,7 +264,7 @@ impl PartitionHierarchy {
             let monitor = global_resource_monitor();
             let memory_limit_mb = monitor.get_memory_limit_mb();
 
-            // Improved memory estimation accounting for worst-case O(n²) behavior:
+            // Improved memory estimation accounting for worst-case O(n²) behaviour:
             // - MergeEvents store full component bitmaps
             // - For chain-like patterns, memory usage is O(n²)
             // - Observed: 100k edges = 1.6GB, 500k edges ≈ 40GB
@@ -276,7 +276,7 @@ impl PartitionHierarchy {
                 // Medium datasets: use middle-ground estimate
                 10_000
             } else {
-                // Small datasets: use optimistic estimate (normal O(n) behavior)
+                // Small datasets: use optimistic estimate (normal O(n) behaviour)
                 1_000
             };
 
@@ -476,18 +476,32 @@ impl PartitionHierarchy {
                             component_manager.get_or_create_component(root_src, src);
                         let component_dst =
                             component_manager.get_or_create_component(root_dst, dst);
-                        let merging_components = vec![component_src, component_dst];
+
+                        // Determine parent and child for binary merge
+                        // Parent is the partition with the smaller canonical ID (more stable)
+                        let (parent_bitmap, child_bitmap) =
+                            if component_src.min().unwrap() < component_dst.min().unwrap() {
+                                (&component_src, &component_dst)
+                            } else {
+                                (&component_dst, &component_src)
+                            };
+
+                        let parent_id = parent_bitmap
+                            .min()
+                            .expect("Parent component cannot be empty");
+                        let child_nodes = child_bitmap.clone();
 
                         uf.union(src as usize, dst as usize);
                         let new_root = uf.find(src as usize);
 
-                        let merged_component =
-                            component_manager.create_merged_component(&merging_components);
+                        let merged_component = component_manager
+                            .create_merged_component(&[&component_src, &component_dst]);
 
                         // Record merge for chain pattern detection
-                        chain_detector.record_merge(&merged_component, &merging_components);
+                        chain_detector
+                            .record_merge(&merged_component, &[&component_src, &component_dst]);
 
-                        let merge_event = MergeEvent::new(*threshold, merging_components);
+                        let merge_event = MergeEvent::new(*threshold, parent_id, child_nodes);
                         self.storage
                             .push(merge_event)
                             .map_err(|e| format!("Storage error: {}", e))?;
@@ -678,19 +692,9 @@ impl PartitionHierarchy {
                 break;
             }
 
-            // Collect all records from all merging groups
-            let mut all_records = Vec::new();
-            for group in &merge.merging_groups {
-                for record in group.iter() {
-                    all_records.push(record);
-                }
-            }
-
-            // Union all records together (using first as representative)
-            if let Some(&first) = all_records.first() {
-                for &record in all_records.iter().skip(1) {
-                    uf.union(first as usize, record as usize);
-                }
+            // Apply binary delta: union all child nodes with parent
+            for node in merge.child_nodes.iter() {
+                uf.union(merge.parent_id as usize, node as usize);
             }
         }
 
@@ -865,11 +869,11 @@ mod tests {
 
         // First merge should be at threshold 0.8 (A-B)
         assert_eq!(merges[0].threshold, 0.8);
-        assert_eq!(merges[0].merging_groups.len(), 2); // Two singletons merge
+        assert_eq!(merges[0].child_nodes.len(), 1); // Binary merge: one singleton absorbed
 
         // Second merge should be at threshold 0.6 ((A,B)-C)
         assert_eq!(merges[1].threshold, 0.6);
-        assert_eq!(merges[1].merging_groups.len(), 2); // Group {A,B} merges with {C}
+        assert_eq!(merges[1].child_nodes.len(), 1); // Binary merge: singleton C absorbed
     }
 
     #[test]
@@ -893,12 +897,9 @@ mod tests {
         // Should have two independent merge events
         assert_eq!(hierarchy.merge_events_count(), 2);
 
-        // Each merge should involve exactly 2 singletons
+        // Each merge should be binary (parent + child)
         for merge in hierarchy.storage.iter().unwrap() {
-            assert_eq!(merge.merging_groups.len(), 2);
-            for group in &merge.merging_groups {
-                assert_eq!(group.len(), 1); // Each group is a singleton
-            }
+            assert_eq!(merge.child_nodes.len(), 1); // Each child is a singleton
         }
     }
 

--- a/src/rust/starlings-core/src/hierarchy/incremental.rs
+++ b/src/rust/starlings-core/src/hierarchy/incremental.rs
@@ -159,27 +159,15 @@ impl IncrementalPartitionBuilder {
         uf: &mut UnionFind<B>,
         merge: &MergeEvent,
     ) {
-        // Collect all records from all merging groups
-        let all_records: Vec<u32> = merge
-            .merging_groups
-            .iter()
-            .flat_map(|group| group.iter())
-            .collect();
-
-        // Early return if no records to merge
-        let Some(&first) = all_records.first() else {
-            return;
-        };
-
-        // Union all records together (using first as representative)
-        for &record in &all_records[1..] {
-            uf.union(first as usize, record as usize);
+        // Apply binary delta: union all child nodes with parent
+        for node in merge.child_nodes.iter() {
+            uf.union(merge.parent_id as usize, node as usize);
         }
 
-        // Update canonical ID for the new root
-        let root = uf.find(first as usize);
-        let min_record = all_records.into_iter().min().unwrap_or(first);
-        self.canonical_ids.insert(root, min_record);
+        // Update canonical ID for the merged entity
+        let root = uf.find(merge.parent_id as usize);
+        // Parent ID is already the canonical ID, so keep it
+        self.canonical_ids.insert(root, merge.parent_id);
     }
 
     /// Build a PartitionLevel from the current union-find state

--- a/src/rust/starlings-core/src/hierarchy/merge_event.rs
+++ b/src/rust/starlings-core/src/hierarchy/merge_event.rs
@@ -1,52 +1,75 @@
 use roaring::RoaringBitmap;
 
-/// Represents a merge event at a specific threshold
+/// Represents a binary merge event at a specific threshold
 ///
-/// A merge event captures the moment when multiple groups of entities
-/// are merged together at a given threshold. Each group is represented
-/// as a RoaringBitmap containing the record indices that belong to that group.
+/// A merge event captures a single binary merge where one partition (child)
+/// is absorbed into another partition (parent). This binary delta format
+/// stores only the absorbed partition's nodes, not the full merged state.
 ///
-/// This supports n-way merges when multiple edges have the same threshold,
-/// allowing multiple groups to merge simultaneously.
+/// # Memory Efficiency
+///
+/// By storing only the delta (child nodes), this achieves O(N) total memory
+/// usage across all events, compared to O(N²) when storing full state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MergeEvent {
     /// The threshold at which this merge occurs
     pub threshold: f64,
 
-    /// Groups merging at this threshold (supports n-way merges)
-    /// Each RoaringBitmap contains the record indices in that group
-    pub merging_groups: Vec<RoaringBitmap>,
+    /// Canonical ID of the partition that survives (parent)
+    pub parent_id: u32,
+
+    /// Complete bitmap of the partition being absorbed (child)
+    pub child_nodes: RoaringBitmap,
 }
 
 impl MergeEvent {
-    /// Create a new merge event
-    pub fn new(threshold: f64, merging_groups: Vec<RoaringBitmap>) -> Self {
+    /// Create a new binary delta merge event
+    ///
+    /// # Arguments
+    /// * `threshold` - Similarity threshold at which merge occurs
+    /// * `parent_id` - Canonical ID of surviving partition
+    /// * `child_nodes` - Complete bitmap of absorbed partition
+    ///
+    /// # Panics
+    /// Panics if child_nodes is empty (invalid merge)
+    pub fn new(threshold: f64, parent_id: u32, child_nodes: RoaringBitmap) -> Self {
+        assert!(
+            !child_nodes.is_empty(),
+            "child_nodes cannot be empty in merge event"
+        );
         Self {
             threshold,
-            merging_groups,
+            parent_id,
+            child_nodes,
         }
     }
 
-    /// Get the total number of entities involved in this merge
-    pub fn total_entities(&self) -> u64 {
-        self.merging_groups.iter().map(|group| group.len()).sum()
+    /// Get canonical ID of child partition (minimum record in child_nodes)
+    pub fn child_id(&self) -> u32 {
+        self.child_nodes
+            .min()
+            .expect("child_nodes validated in constructor")
     }
 
-    /// Check if this merge event affects a specific record
+    /// Get approximate number of entities involved
+    ///
+    /// Returns child size + 1 (for parent). This is approximate because
+    /// we don't store the parent's full size.
+    pub fn total_entities(&self) -> u64 {
+        self.child_nodes.len() + 1
+    }
+
+    /// Check if this merge affects a specific record
+    ///
+    /// Only checks child nodes. Records in parent partition are not
+    /// stored in the event (delta representation).
     pub fn affects_record(&self, record_id: u32) -> bool {
-        self.merging_groups
-            .iter()
-            .any(|group| group.contains(record_id))
+        self.child_nodes.contains(record_id)
     }
 
     /// Get the threshold of this merge event
     pub fn threshold(&self) -> f64 {
         self.threshold
-    }
-
-    /// Get the merging groups
-    pub fn merging_groups(&self) -> &[RoaringBitmap] {
-        &self.merging_groups
     }
 }
 
@@ -56,31 +79,36 @@ mod tests {
 
     #[test]
     fn test_merge_event_creation() {
-        let mut group1 = RoaringBitmap::new();
-        group1.insert(1);
-        group1.insert(2);
+        let mut child_bitmap = RoaringBitmap::new();
+        child_bitmap.insert(10);
+        child_bitmap.insert(11);
 
-        let mut group2 = RoaringBitmap::new();
-        group2.insert(3);
-        group2.insert(4);
+        let event = MergeEvent::new(0.8, 5, child_bitmap);
 
-        let merge = MergeEvent::new(0.8, vec![group1, group2]);
-
-        assert_eq!(merge.threshold, 0.8);
-        assert_eq!(merge.merging_groups.len(), 2);
-        assert_eq!(merge.total_entities(), 4);
+        assert_eq!(event.threshold, 0.8);
+        assert_eq!(event.parent_id, 5);
+        assert_eq!(event.child_id(), 10); // min of {10, 11}
+        assert_eq!(event.total_entities(), 3); // child.len() + 1
     }
 
     #[test]
     fn test_affects_record() {
-        let mut group1 = RoaringBitmap::new();
-        group1.insert(1);
-        group1.insert(2);
+        let mut child_bitmap = RoaringBitmap::new();
+        child_bitmap.insert(1);
+        child_bitmap.insert(2);
 
-        let merge = MergeEvent::new(0.7, vec![group1]);
+        let merge = MergeEvent::new(0.7, 0, child_bitmap);
 
-        assert!(merge.affects_record(1));
-        assert!(merge.affects_record(2));
-        assert!(!merge.affects_record(3));
+        assert!(merge.affects_record(1)); // In child
+        assert!(merge.affects_record(2)); // In child
+        assert!(!merge.affects_record(0)); // Parent not in child_nodes
+        assert!(!merge.affects_record(3)); // Not involved
+    }
+
+    #[test]
+    #[should_panic(expected = "child_nodes cannot be empty")]
+    fn test_empty_child_nodes_panics() {
+        let empty_bitmap = RoaringBitmap::new();
+        MergeEvent::new(0.5, 0, empty_bitmap); // Should panic
     }
 }

--- a/src/rust/starlings-core/src/hierarchy/storage.rs
+++ b/src/rust/starlings-core/src/hierarchy/storage.rs
@@ -106,7 +106,7 @@ impl HierarchyStorage for InMemoryStorage {
         let bitmap_size: u64 = self
             .events
             .iter()
-            .map(|e| e.merging_groups.iter().map(|b| b.len() * 4).sum::<u64>()) // Rough estimate: 4 bytes per element
+            .map(|e| e.child_nodes.len() * 4) // Only one bitmap per event now
             .sum();
         (event_overhead as u64) + bitmap_size
     }
@@ -191,32 +191,34 @@ impl DiskStorage {
         // Write threshold as 8 bytes
         buffer.extend_from_slice(&event.threshold.to_le_bytes());
 
-        // Write number of groups as 4 bytes
-        buffer.extend_from_slice(&(event.merging_groups.len() as u32).to_le_bytes());
+        // Write parent_id as 4 bytes
+        buffer.extend_from_slice(&event.parent_id.to_le_bytes());
 
-        // Write each bitmap
-        for bitmap in &event.merging_groups {
-            let mut bitmap_data = Vec::new();
-            bitmap.serialize_into(&mut bitmap_data).map_err(|e| {
+        // Write child_nodes bitmap
+        let mut bitmap_data = Vec::new();
+        event
+            .child_nodes
+            .serialize_into(&mut bitmap_data)
+            .map_err(|e| {
                 StorageError::Serialization(format!("Bitmap serialization failed: {}", e))
             })?;
-            // Write bitmap size as 4 bytes, then bitmap data
-            buffer.extend_from_slice(&(bitmap_data.len() as u32).to_le_bytes());
-            buffer.extend_from_slice(&bitmap_data);
-        }
+
+        // Write bitmap size as 4 bytes, then bitmap data
+        buffer.extend_from_slice(&(bitmap_data.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(&bitmap_data);
 
         Ok(buffer)
     }
 
     fn deserialize_event(data: &[u8]) -> Result<MergeEvent, StorageError> {
-        if data.len() < 12 {
-            // At least threshold + group count + one bitmap size
+        if data.len() < 16 {
+            // threshold + parent_id + bitmap_size minimum
             return Err(StorageError::Serialization("Data too short".to_string()));
         }
 
         let mut offset = 0;
 
-        // Read threshold
+        // Read threshold (8 bytes)
         let threshold = f64::from_le_bytes(
             data[offset..offset + 8]
                 .try_into()
@@ -224,43 +226,34 @@ impl DiskStorage {
         );
         offset += 8;
 
-        // Read number of groups
-        let num_groups =
+        // Read parent_id (4 bytes)
+        let parent_id = u32::from_le_bytes(
+            data[offset..offset + 4]
+                .try_into()
+                .map_err(|_| StorageError::Serialization("Invalid parent_id bytes".to_string()))?,
+        );
+        offset += 4;
+
+        // Read bitmap size (4 bytes)
+        let bitmap_size =
             u32::from_le_bytes(data[offset..offset + 4].try_into().map_err(|_| {
-                StorageError::Serialization("Invalid group count bytes".to_string())
+                StorageError::Serialization("Invalid bitmap size bytes".to_string())
             })?) as usize;
         offset += 4;
 
-        // Read each bitmap
-        let mut merging_groups = Vec::with_capacity(num_groups);
-        for _ in 0..num_groups {
-            if offset + 4 > data.len() {
-                return Err(StorageError::Serialization(
-                    "Unexpected end of data".to_string(),
-                ));
-            }
-
-            let bitmap_size =
-                u32::from_le_bytes(data[offset..offset + 4].try_into().map_err(|_| {
-                    StorageError::Serialization("Invalid bitmap size bytes".to_string())
-                })?) as usize;
-            offset += 4;
-
-            if offset + bitmap_size > data.len() {
-                return Err(StorageError::Serialization(
-                    "Bitmap data truncated".to_string(),
-                ));
-            }
-
-            let bitmap = RoaringBitmap::deserialize_from(&data[offset..offset + bitmap_size])
-                .map_err(|e| {
-                    StorageError::Serialization(format!("Bitmap deserialization failed: {}", e))
-                })?;
-            merging_groups.push(bitmap);
-            offset += bitmap_size;
+        if offset + bitmap_size > data.len() {
+            return Err(StorageError::Serialization(
+                "Bitmap data truncated".to_string(),
+            ));
         }
 
-        Ok(MergeEvent::new(threshold, merging_groups))
+        // Read child_nodes bitmap
+        let child_nodes = RoaringBitmap::deserialize_from(&data[offset..offset + bitmap_size])
+            .map_err(|e| {
+                StorageError::Serialization(format!("Bitmap deserialization failed: {}", e))
+            })?;
+
+        Ok(MergeEvent::new(threshold, parent_id, child_nodes))
     }
 }
 
@@ -403,15 +396,13 @@ impl std::fmt::Debug for DiskStorage {
 mod tests {
     use super::*;
 
-    fn create_test_merge_event(threshold: f64, num_groups: usize) -> MergeEvent {
-        let mut groups = Vec::new();
-        for i in 0..num_groups {
-            let mut bitmap = RoaringBitmap::new();
-            bitmap.insert((i * 10) as u32);
-            bitmap.insert((i * 10 + 1) as u32);
-            groups.push(bitmap);
+    fn create_test_merge_event(threshold: f64, num_records: usize) -> MergeEvent {
+        // num_records parameter controls size of child_nodes
+        let mut child_bitmap = RoaringBitmap::new();
+        for i in 0..num_records {
+            child_bitmap.insert((10 + i) as u32);
         }
-        MergeEvent::new(threshold, groups)
+        MergeEvent::new(threshold, 0, child_bitmap) // parent_id=0
     }
 
     #[test]
@@ -430,7 +421,8 @@ mod tests {
 
         let retrieved = storage.get(0).unwrap().unwrap();
         assert_eq!(retrieved.threshold, 0.8);
-        assert_eq!(retrieved.merging_groups.len(), 2);
+        assert_eq!(retrieved.parent_id, 0);
+        assert_eq!(retrieved.child_nodes.len(), 2);
     }
 
     #[test]
@@ -442,18 +434,8 @@ mod tests {
         let deserialized = DiskStorage::deserialize_event(&serialized).unwrap();
 
         assert_eq!(deserialized.threshold, event.threshold);
-        assert_eq!(
-            deserialized.merging_groups.len(),
-            event.merging_groups.len()
-        );
-
-        for (orig, deser) in event
-            .merging_groups
-            .iter()
-            .zip(&deserialized.merging_groups)
-        {
-            assert_eq!(orig, deser);
-        }
+        assert_eq!(deserialized.parent_id, event.parent_id);
+        assert_eq!(deserialized.child_nodes, event.child_nodes);
     }
 
     #[test]
@@ -500,13 +482,11 @@ mod tests {
         let read_events: Vec<_> = storage.iter()?.collect();
         assert_eq!(read_events.len(), 3);
 
-        // Verify events match by checking thresholds (they should be in same order)
+        // Verify events match by checking thresholds and structure
         for (i, read_event) in read_events.iter().enumerate() {
             assert_eq!(read_event.threshold, events[i].threshold);
-            assert_eq!(
-                read_event.merging_groups.len(),
-                events[i].merging_groups.len()
-            );
+            assert_eq!(read_event.parent_id, events[i].parent_id);
+            assert_eq!(read_event.child_nodes, events[i].child_nodes);
         }
 
         Ok(())

--- a/src/rust/starlings-core/src/metrics/algorithms/delta.rs
+++ b/src/rust/starlings-core/src/metrics/algorithms/delta.rs
@@ -457,24 +457,6 @@ impl DeltaAlgorithm {
         // Cache single partition metrics
         state.last_entity_count = Some(state.row_marginals.len() as f64);
 
-        // Calculate entropy for partition1
-        if state.total_records > 0 {
-            let mut entropy = 0.0;
-            let total = state.total_records as f64;
-            for &size in state.row_marginals.values() {
-                if size > 0 {
-                    let proportion = size as f64 / total;
-                    entropy -= proportion * proportion.log2();
-                }
-            }
-            state.last_entropy = Some(entropy);
-        } else {
-            state.last_entropy = Some(0.0);
-        }
-
-        // Calculate initial single partition metrics
-        state.last_entity_count = Some(state.row_marginals.len() as f64);
-
         // Calculate initial entropy from marginals
         if state.total_records > 0 {
             let mut entropy = 0.0;
@@ -588,31 +570,18 @@ impl DeltaAlgorithm {
             //     event.merging_groups().len()
             // );
 
-            // Each merge event contains groups that are merging
+            // Each merge event is a binary merge: parent absorbs child
             // We need to:
-            // 1. Find which old entities these groups represent
+            // 1. Get the canonical IDs of parent and child
             // 2. Update our state to reflect the merge
 
-            let groups = event.merging_groups();
-            if groups.len() < 2 {
-                continue; // No actual merge if less than 2 groups
-            }
+            // Binary delta: we have parent and child
+            let child_canonical = event.child_id();
+            let parent_canonical = event.parent_id;
 
-            // Find canonical IDs of merging entities
-            let mut merging_canonicals = Vec::new();
-            for group in groups {
-                // The minimum record in each group is its canonical ID
-                if let Some(min_record) = group.min() {
-                    merging_canonicals.push(min_record);
-                }
-            }
-
-            if merging_canonicals.len() < 2 {
-                continue; // No merge needed
-            }
-
-            // The new canonical ID is the minimum of all merging canonicals
-            let new_canonical = *merging_canonicals.iter().min().unwrap();
+            // The parent becomes the new canonical ID (it's the "winner")
+            let new_canonical = parent_canonical;
+            let merging_canonicals = vec![parent_canonical, child_canonical];
 
             // Update row marginals: sum the sizes of merging entities
             let mut merged_size = 0u32;


### PR DESCRIPTION
MergeEvents were storing massive RoaringBitmaps, so that 500k of chained edges needed 30Gb of memory. We now only store (and bitmap) the delta, meaning even a chain will need far less.